### PR TITLE
Add Uni-CLI under Open Source > Frameworks & Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,8 +485,9 @@ A curated list of resources about AI agents for Computer Use, including research
   - Integrated Browser Use and Computer Use
 
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)
-  - Universal CLI hub connecting agents to 238 sites, desktop apps, and browser automation via 1,458 declarative commands
-  - Stagehand-style `operate observe` verb, raw CDP (no extension), production MCP gateway, structured error envelopes for self-repair; per-call token budget in [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)
+  - Universal CLI hub connecting agents to web, desktop apps, Electron apps, and browser automation via declarative YAML adapters
+  - Stagehand-style `operate observe` verb, raw CDP (no extension), production MCP gateway, structured error envelopes for self-repair
+  - Live catalog size and per-call token budget tracked in the repo's [README](https://github.com/olo-dot-io/Uni-CLI#readme) and [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)
 
 <br/>
 </details>

--- a/README.md
+++ b/README.md
@@ -483,7 +483,10 @@ A curated list of resources about AI agents for Computer Use, including research
 - [Upsonic](https://github.com/upsonic/upsonic)  
   - Reliable agent framework that support MCP 
   - Integrated Browser Use and Computer Use
- 
+
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)
+  - Universal CLI hub connecting agents to 134 sites, desktop apps, and browser automation via 711 declarative YAML pipelines
+  - Stagehand-style `operate observe` verb, raw CDP (no extension), production MCP gateway, Karpathy-style self-repair loop, ~80 tokens per call
 
 <br/>
 </details>

--- a/README.md
+++ b/README.md
@@ -485,8 +485,8 @@ A curated list of resources about AI agents for Computer Use, including research
   - Integrated Browser Use and Computer Use
 
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)
-  - Universal CLI hub connecting agents to 134 sites, desktop apps, and browser automation via 711 declarative YAML pipelines
-  - Stagehand-style `operate observe` verb, raw CDP (no extension), production MCP gateway, Karpathy-style self-repair loop, ~80 tokens per call
+  - Universal CLI hub connecting agents to 238 sites, desktop apps, and browser automation via 1,458 declarative commands
+  - Stagehand-style `operate observe` verb, raw CDP (no extension), production MCP gateway, structured error envelopes for self-repair; per-call token budget in [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)
 
 <br/>
 </details>


### PR DESCRIPTION
## Proposed entry

Adds Uni-CLI to **Projects → Open Source → Frameworks & Models**, placed after Upsonic:

\`\`\`md
- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)
  - Universal CLI hub connecting agents to 134 sites, desktop apps, and browser automation via 711 declarative YAML pipelines
  - Stagehand-style \`operate observe\` verb, raw CDP (no extension), production MCP gateway, Karpathy-style self-repair loop, ~80 tokens per call
\`\`\`

## Why it belongs in this list

Uni-CLI is a computer-use-adjacent framework that covers the **deterministic, low-token** end of the agent-tooling spectrum:

- **Browser control (computer use)**: raw CDP driver (no Chrome extension required), DOM snapshot with accessibility-tree refs, Stagehand-style \`observe → act → extract\` verbs. \`unicli operate observe \"click the submit button\"\` returns ranked candidate elements with confidence scores and reason strings.
- **Desktop apps**: subprocess adapters for Blender, MuseScore, GIMP, Inkscape, ImageMagick, FFmpeg, LibreOffice, Pandoc, Docker, kdenlive, shotcut, audacity, Zotero, freecad, cloudcompare, ComfyUI, and more.
- **Web APIs**: 60+ sites (Hacker News, Reddit, GitHub, Twitter, YouTube, Bilibili, Weibo, Xiaohongshu, Zhihu, Douyin, Bloomberg, Reuters, Amazon, LinkedIn, Instagram, ChatGPT, Claude Code CDP, Cursor CDP, Notion, Discord, …)
- **Self-repair**: when an adapter breaks (selector drift, API version bump, auth rotation), the agent reads the 20-line YAML at the reported path, edits it, and retries — the Karpathy self-repair loop made explicit in 8 phases.

## Comparison context (for maintainers)

- vs **Browser Use**: different shape. Browser Use is a Python library agents \`import\`; Uni-CLI is a CLI binary agents \`exec\`. ~80 tokens per Uni-CLI call vs per-step LLM tokens.
- vs **Skyvern / LaVague / Notte / Surfkit**: Uni-CLI's browser is deterministic YAML pipelines (with optional LLM grounding for the \`observe\` verb), while those are vision+LLM-per-step.
- vs **CUA (this list's own project)**: CUA provides the sandbox (macOS/Linux on Apple Silicon); Uni-CLI provides the control surface. They compose — \`unicli\` can run inside a CUA sandbox.

## Release info

- **v0.208.0** just released: https://github.com/olo-dot-io/Uni-CLI/releases/tag/v0.208.0
- npm: https://www.npmjs.com/package/@zenalexa/unicli
- License: Apache-2.0
- Full docs: [docs/COMPARE.md](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/COMPARE.md), [docs/MCP-GATEWAY.md](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/MCP-GATEWAY.md)

Happy to adjust the entry position, wording, or move it to Automation if you think it fits there better. Thanks for maintaining the list!